### PR TITLE
Update scatter defaults

### DIFF
--- a/cnvlib/batch.py
+++ b/cnvlib/batch.py
@@ -307,7 +307,12 @@ def batch_run_sample(
 
     if plot_scatter:
         scatter.do_scatter(cnarr, seg_final)
-        pyplot.savefig(sample_pfx + "-scatter.png", format="png", bbox_inches="tight")
+        pyplot.savefig(
+            sample_pfx + "-scatter.png",
+            format="png",
+            bbox_inches="tight",
+            dpi=400,
+        )
         logging.info("Wrote %s-scatter.png", sample_pfx)
 
     if plot_diagram:

--- a/cnvlib/commands.py
+++ b/cnvlib/commands.py
@@ -1495,7 +1495,7 @@ def _cmd_scatter(args):
                 except ValueError as exc:
                     # Probably no bins in the selected region
                     logging.warning("Not plotting region %r: %s", to_label(region), exc)
-                pdf_out.savefig()
+                pdf_out.savefig(dpi=400)
                 pyplot.close()
     else:
         if args.title is not None:
@@ -1505,7 +1505,7 @@ def _cmd_scatter(args):
         )
         if args.output:
             oformat = os.path.splitext(args.output)[-1].replace(".", "")
-            pyplot.savefig(args.output, format=oformat, bbox_inches="tight")
+            pyplot.savefig(args.output, format=oformat, bbox_inches="tight", dpi=400)
             logging.info("Wrote %s", args.output)
         else:
             pyplot.show()
@@ -1595,8 +1595,8 @@ P_scatter_aes.add_argument(
     nargs=2,
     metavar=("WIDTH", "HEIGHT"),
     type=float,
-    help="""Width and height of the plot in inches. [Default: Pre-defined in Matplotlib
-            'rcParams' variable (most of the time: '6.4 4.8')]""",
+    default=(32, 6),
+    help="""Width and height of the plot in inches. [Default: 32 6]""",
 )
 
 P_scatter_vcf = P_scatter.add_argument_group("To plot SNP b-allele frequencies")

--- a/cnvlib/scatter.py
+++ b/cnvlib/scatter.py
@@ -27,7 +27,7 @@ def do_scatter(
     window_width=1e6,
     y_min=None,
     y_max=None,
-    fig_size=None,
+    fig_size=(32, 6),
     antitarget_marker=None,
     segment_color=SEG_COLOR,
     title=None,


### PR DESCRIPTION
## Summary
- default scatter figure size is 32x6
- save PNG/PDF scatter plots at 400 dpi

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6864a33a25a08327aba852ab1f83292b